### PR TITLE
fix: Use certs when SSL redirect

### DIFF
--- a/templates/apache.redirect
+++ b/templates/apache.redirect
@@ -1,4 +1,9 @@
 <VirtualHost *:{% if item.from_proto == "http" %}80{% else %}443{% endif %}>
 	ServerName {{ item.from }}
 	Redirect permanent / {{ item.to_proto }}://{{ item.to }}/
+{% if item.from_proto == "https" %}
+        # Include /etc/letsencrypt/options-ssl-apache.conf
+        SSLCertificateFile /etc/letsencrypt/live/{{ item.from }}/fullchain.pem
+	SSLCertificateKeyFile /etc/letsencrypt/live/{{ item.from }}/privkey.pem
+{% endif %}
 </VirtualHost>

--- a/templates/nginx.redirect
+++ b/templates/nginx.redirect
@@ -1,5 +1,9 @@
 server {
      listen {% if item.from_proto == "http" %}80{% else %}443{% endif %};
      server_name {{ item.from }};
+{% if item.from_proto == "http" %}
+     ssl_certificate /etc/letsencrypt/live/{{ item.from }}/fullchain.pem;
+     ssl_certificate_key /etc/letsencrypt/live/{{ item.from }}/privkey.pem;
+{% endif %}
      return 301 {{ item.to_proto }}://{{ item.to }}/;
 }


### PR DESCRIPTION
On 443 redirection, we should provide cert files